### PR TITLE
Reduce, Reuse, Refuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,15 +219,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
-name = "intrusive-collections"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca8c0bb831cd60d4dda79a58e3705ca6eb47efb65d665651a8d672213ec3db"
-dependencies = [
- "memoffset",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,15 +244,6 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mio"
@@ -519,7 +501,6 @@ dependencies = [
  "exitcode",
  "futures",
  "futures-util",
- "intrusive-collections",
  "log",
  "privdrop",
  "rusty-sandbox",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "cc"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -226,9 +226,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "log"
@@ -270,13 +270,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85db2feff6bf70ebc3a4793191517d5f0331100a2f10f9bf93b5e5214f32b7b7"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -466,9 +466,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.51"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "tarssh"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "env_logger",
  "exitcode",
@@ -544,9 +544,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
+checksum = "a12a3eb39ee2c231be64487f1fcbe726c8f2514876a55480a5ab8559fc374252"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
+name = "retain_mut"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e005d658ad26eacc2b6c506dfde519f4e277e328d0eb3379ca61647d70a8f531"
+
+[[package]]
 name = "rusty-sandbox"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +509,7 @@ dependencies = [
  "futures-util",
  "log",
  "privdrop",
+ "retain_mut",
  "rusty-sandbox",
  "structopt",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca8c0bb831cd60d4dda79a58e3705ca6eb47efb65d665651a8d672213ec3db"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +253,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -287,16 +305,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -511,6 +519,7 @@ dependencies = [
  "exitcode",
  "futures",
  "futures-util",
+ "intrusive-collections",
  "log",
  "privdrop",
  "rusty-sandbox",
@@ -553,15 +562,27 @@ checksum = "9dfe2523e6fa84ddf5e688151d4e5fddc51678de9752c6512a24714c23818d61"
 dependencies = [
  "autocfg",
  "bytes",
+ "futures-core",
  "lazy_static",
  "libc",
  "memchr",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ futures-util = "0.3.4"
 log = "0.4.8"
 structopt = "0.3.11"
 tokio = { version = "0.3", features = ["io-util", "macros", "net", "rt", "signal", "stream", "sync", "time"] }
+retain_mut = "0.1.1"
 
 [target."cfg(unix)".dependencies]
 rusty-sandbox = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ futures = "0.3.4"
 futures-util = "0.3.4"
 log = "0.4.8"
 structopt = "0.3.11"
-tokio = { version = "0.3", features = ["io-util", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "0.3", features = ["io-util", "macros", "net", "rt", "signal", "stream", "sync", "time"] }
+intrusive-collections = "0.9.0"
 
 [target."cfg(unix)".dependencies]
 rusty-sandbox = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tarssh"
-version = "0.5.0"
+version = "0.6.0"
 description = "A simple SSH tarpit server"
 authors = ["Thomas Hurst <tom@hur.st>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ futures-util = "0.3.4"
 log = "0.4.8"
 structopt = "0.3.11"
 tokio = { version = "0.3", features = ["io-util", "macros", "net", "rt", "signal", "stream", "sync", "time"] }
-intrusive-collections = "0.9.0"
 
 [target."cfg(unix)".dependencies]
 rusty-sandbox = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ that's one less free connection for the next attack.
 ```console
 -% cargo install tarssh
 -% tarssh --help
-tarssh 0.5.0
+tarssh 0.6.0
 A SSH tarpit server
 
 USAGE:
@@ -47,25 +47,21 @@ OPTIONS:
     -g, --group <group>                Run as this group
     -l, --listen <listen>...           Listen address(es) to bind to [default: 0.0.0.0:2222]
     -c, --max-clients <max-clients>    Best-effort connection limit [default: 4096]
-        --threads <threads>            Use threads, with optional thread count
     -t, --timeout <timeout>            Socket write timeout [default: 30]
     -u, --user <user>                  Run as this user and their primary group
 
-
-
--% tarssh -v --disable-log-timestamps -l 0.0.0.0:2222 \[::]:2222
-[INFO  tarssh] init, version: 0.5.0, scheduler: basic
-[INFO  tarssh] listen, addr: 0.0.0.0:2222
-[INFO  tarssh] listen, addr: [::]:2222
-[INFO  tarssh] privdrop, enabled: false
-[INFO  tarssh] sandbox, enabled: true
-[INFO  tarssh] start, servers: 2, max_clients: 4096, delay: 10s, timeout: 30s
-[INFO  tarssh] connect, peer: 127.0.0.1:39410, clients: 1
-[INFO  tarssh] connect, peer: 127.0.0.1:39424, clients: 2
-[INFO  tarssh] disconnect, peer: 127.0.0.1:39410, duration: 20.02s, error: "Broken pipe (os error 32)", clients: 1
-[INFO  tarssh] disconnect, peer: 127.0.0.1:39424, duration: 20.06s, error: "Broken pipe (os error 32)", clients: 0
-^C[INFO  tarssh] interrupt
-[INFO  tarssh] shutdown, uptime: 71.50s, clients: 0
+-% tarssh -v --disable-log-timestamps --disable-log-ident -l 0.0.0.0:2222 \[::]:2222
+[INFO ] init, pid: 90127, version: 0.6.0
+[INFO ] listen, addr: 0.0.0.0:2222
+[INFO ] listen, addr: [::]:2222
+[INFO ] privdrop, enabled: false
+[INFO ] sandbox, enabled: true
+[INFO ] start, servers: 2, max_clients: 4096, delay: 10s, timeout: 30s
+[INFO ] connect, peer: 127.0.0.1:20981, clients: 1
+[INFO ] connect, peer: 127.0.0.1:20984, clients: 2
+[INFO ] disconnect, peer: 127.0.0.1:20981, duration: 20.02s, bytes: 24, error: "Broken pipe (os error 32)", clients: 1
+[INFO ] disconnect, peer: 127.0.0.1:20984, duration: 19.14s, bytes: 24, error: "Broken pipe (os error 32)", clients: 0
+^C[INFO ] shutdown, pid: 90127, signal: INT, uptime: 25.01s, clients: 0, total: 2, bytes: 48
 ```
 
 [Tokio]: https://tokio.rs

--- a/README.md
+++ b/README.md
@@ -51,18 +51,24 @@ OPTIONS:
     -u, --user <user>                  Run as this user and their primary group
 
 -% tarssh -v --disable-log-timestamps --disable-log-ident -l 0.0.0.0:2222 \[::]:2222
-[INFO ] init, pid: 90127, version: 0.6.0
+[INFO ] init, pid: 27344, version: 0.6.0
 [INFO ] listen, addr: 0.0.0.0:2222
 [INFO ] listen, addr: [::]:2222
 [INFO ] privdrop, enabled: false
 [INFO ] sandbox, enabled: true
 [INFO ] start, servers: 2, max_clients: 4096, delay: 10s, timeout: 30s
-[INFO ] connect, peer: 127.0.0.1:20981, clients: 1
-[INFO ] connect, peer: 127.0.0.1:20984, clients: 2
-[INFO ] disconnect, peer: 127.0.0.1:20981, duration: 20.02s, bytes: 24, error: "Broken pipe (os error 32)", clients: 1
-[INFO ] disconnect, peer: 127.0.0.1:20984, duration: 19.14s, bytes: 24, error: "Broken pipe (os error 32)", clients: 0
-^C[INFO ] shutdown, pid: 90127, signal: INT, uptime: 25.01s, clients: 0, total: 2, bytes: 48
+[INFO ] connect, peer: 127.0.0.1:61986, clients: 1
+[INFO ] connect, peer: 127.0.0.1:61988, clients: 2
+load: 1.05  cmd: tarssh 27344 [kqread] 6.92r 0.00u 0.00s 0% 4512k
+[INFO ] info, pid: 27344, signal: INFO, uptime: 6.92s, clients: 2, total: 2, bytes: 0
+[INFO ] disconnect, peer: 127.0.0.1:61986, duration: 19.80s, bytes: 24, error: "Broken pipe (os error 32)", clients: 1
+[INFO ] disconnect, peer: 127.0.0.1:61988, duration: 19.62s, bytes: 24, error: "Broken pipe (os error 32)", clients: 0
+^C[INFO ] shutdown, pid: 27344, signal: INT, uptime: 25.39s, clients: 0, total: 2, bytes: 48
 ```
+
+The `info` line is generated using a BSD `SIGINFO` signal - `SIGHUP` is also
+supported for Unix platforms lacking this.
+
 
 [Tokio]: https://tokio.rs
 [rusty-sandbox]: https://github.com/myfreeweb/rusty-sandbox

--- a/src/elapsed.rs
+++ b/src/elapsed.rs
@@ -1,0 +1,34 @@
+
+use std::fmt;
+use std::time::{Duration, Instant};
+
+/// A tiny type for tracking approximate Durations from a known starting point
+/// Wraps every 13.6 years, precision of 1 decisecond (100ms)
+#[derive(Copy, Clone)]
+pub struct Elapsed(u32);
+
+impl From<Instant> for Elapsed {
+    fn from(start: Instant) -> Self {
+        let duration = start.elapsed();
+        Self(duration.as_secs() as u32 * 10 + (duration.subsec_millis() as f32 / 100.0) as u32)
+    }
+}
+
+impl From<Elapsed> for Duration {
+    fn from(elapsed: Elapsed) -> Self {
+        Duration::from_millis(elapsed.0 as u64 * 100)
+    }
+}
+
+impl Elapsed {
+    pub fn elapsed(&self, start: Instant) -> Duration {
+        start.elapsed() - Duration::from(*self)
+    }
+}
+
+
+impl fmt::Debug for Elapsed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Duration::from(*self).fmt(f)
+    }
+}

--- a/src/elapsed.rs
+++ b/src/elapsed.rs
@@ -1,4 +1,3 @@
-
 use std::fmt;
 use std::time::{Duration, Instant};
 
@@ -25,7 +24,6 @@ impl Elapsed {
         start.elapsed() - Duration::from(*self)
     }
 }
-
 
 impl fmt::Debug for Elapsed {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,9 @@ use structopt::StructOpt;
 use tokio::net::{TcpListener, TcpSocket, TcpStream};
 use tokio::time::sleep;
 
+mod elapsed;
+use elapsed::Elapsed;
+
 #[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
 
@@ -83,37 +86,6 @@ struct PrivDropConfig {
     chroot: Option<PathBuf>,
 }
 
-/// A tiny type for tracking approximate Durations from a known starting point
-/// Wraps every 13.6 years, precision of 1 decisecond (100ms)
-#[derive(Copy, Clone)]
-struct Elapsed(u32);
-
-impl From<Instant> for Elapsed {
-    fn from(start: Instant) -> Self {
-        let duration = start.elapsed();
-        Self(duration.as_secs() as u32 * 10 + (duration.subsec_millis() as f32 / 100.0) as u32)
-    }
-}
-
-impl From<Elapsed> for Duration {
-    fn from(elapsed: Elapsed) -> Self {
-        Duration::from_millis(elapsed.0 as u64 * 100)
-    }
-}
-
-impl Elapsed {
-    fn elapsed(&self, start: Instant) -> Duration {
-        start.elapsed() - Duration::from(*self)
-    }
-}
-
-use std::fmt;
-
-impl fmt::Debug for Elapsed {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Duration::from(*self).fmt(f)
-    }
-}
 
 #[derive(Debug)]
 struct Connection {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ struct Config {
     listen: Vec<SocketAddr>,
     /// Best-effort connection limit
     #[structopt(short = "c", long = "max-clients", default_value = "4096")]
-    max_clients: u32,
+    max_clients: std::num::NonZeroU32,
     /// Seconds between responses
     #[structopt(short = "d", long = "delay", default_value = "10")]
     delay: std::num::NonZeroU16,
@@ -127,7 +127,7 @@ async fn listen_socket(addr: SocketAddr) -> std::io::Result<TcpListener> {
 async fn main() {
     let opt = Config::from_args();
 
-    let max_clients = opt.max_clients as usize;
+    let max_clients = u32::from(opt.max_clients) as usize;
     let delay = Duration::from_secs(u16::from(opt.delay) as u64);
     let timeout = Duration::from_secs(opt.timeout as u64);
     let log_level = match opt.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -252,6 +252,7 @@ async fn main() {
                             connection.failed = 0;
                             return true;
                         },
+                        Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {},
                         Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                             connection.failed += 1;
                             if delay * connection.failed as u32 >= timeout {

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,15 +243,15 @@ async fn main() {
     loop {
         tokio::select! {
             Some(signal) = signals.next() => {
-                info!("signal, kind: {}", signal);
                 let action = match signal {
                     "INFO" | "HUP" => "info",
                     _ => "shutdown",
                 };
                 info!(
-                    "{}, pid: {}, uptime: {:.2?}, clients: {}, total: {}, bytes: {}",
+                    "{}, pid: {}, signal: {}, uptime: {:.2?}, clients: {}, total: {}, bytes: {}",
                     action,
                     std::process::id(),
+                    signal,
                     startup.elapsed(),
                     num_clients,
                     total_clients,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,15 @@ use std::path::PathBuf;
 #[cfg(all(unix, feature = "drop_privs"))]
 use std::ffi::OsString;
 
-static BANNER: &[u8] = "My name is Yon Yonson\r\n\
-    I live in Wisconsin\r\n\
-    There, the people I meet\r\n\
-    As I walk down the street\r\n\
-    Say \"Hey, what's your name\"\r\n\
-    And I say:\r\n"
+static BANNER: &[u8] = "My name is Yon Yonson,\r\n\
+    I live in Wisconsin.\r\n\
+    I work in a lumber yard there.\r\n\
+    The people I meet as\r\n\
+    I walk down the street,\r\n\
+    They say \"Hello!\"\r\n\
+    I say \"Hello!\"\r\n\
+    They say \"What's your name.\"\r\n\
+    I say: "
     .as_bytes();
 
 #[derive(Debug, StructOpt)]
@@ -265,8 +268,8 @@ async fn main() {
             Some((tick, _)) = ticker.next() => {
                 last_tick = tick;
                 slots[tick].retain_mut(|connection| {
-                    let pos = connection.bytes as usize % BANNER.len();
-                    let slice = &BANNER[pos..=pos+BANNER[pos..].iter().position(|b| *b == b'\n').unwrap_or(BANNER.len())];
+                    let pos = &BANNER[connection.bytes as usize % BANNER.len()..];
+                    let slice = &pos[..=pos.iter().position(|b| *b == b'\n').unwrap_or(pos.len() - 1)];
                     match connection.sock.try_write(slice) {
                         Ok(n) => {
                             bytes += n as u64;

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,11 @@ async fn main() {
         .format_level(!opt.disable_log_level)
         .init();
 
-    info!("init, version: {}", env!("CARGO_PKG_VERSION"));
+    info!(
+        "init, pid: {}, version: {}",
+        std::process::id(),
+        env!("CARGO_PKG_VERSION")
+    );
 
     let startup = Instant::now();
 
@@ -210,8 +214,7 @@ async fn main() {
     }
 
     info!(
-        "start, pid: {}, servers: {}, max_clients: {}, delay: {}s, timeout: {}s",
-        std::process::id(),
+        "start, servers: {}, max_clients: {}, delay: {}s, timeout: {}s",
         listeners.len(),
         opt.max_clients,
         delay.as_secs(),
@@ -359,7 +362,10 @@ fn shutdown_stream() -> impl futures::stream::Stream<Item = &'static str> + 'sta
     #[cfg(not(unix))]
     {
         use futures_util::future::FutureExt;
-        tokio::signal::ctrl_c().map(|_| "interrupt").into_stream().boxed()
+        tokio::signal::ctrl_c()
+            .map(|_| "interrupt")
+            .into_stream()
+            .boxed()
     }
 
     #[cfg(unix)]

--- a/src/peer_addr.rs
+++ b/src/peer_addr.rs
@@ -1,6 +1,5 @@
-
-use std::net::{SocketAddr, IpAddr, Ipv6Addr};
 use std::fmt;
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 
 /// A compact representation of an IP and port pair
 #[derive(Debug, Clone, Copy)]
@@ -19,7 +18,7 @@ impl From<&SocketAddr> for PeerAddr {
 
         Self {
             ip,
-            port: peer.port()
+            port: peer.port(),
         }
     }
 }

--- a/src/peer_addr.rs
+++ b/src/peer_addr.rs
@@ -1,0 +1,55 @@
+
+use std::net::{SocketAddr, IpAddr, Ipv6Addr};
+use std::fmt;
+
+/// A compact representation of an IP and port pair
+#[derive(Debug, Clone, Copy)]
+#[repr(packed(2))]
+pub struct PeerAddr {
+    ip: u128,
+    port: u16,
+}
+
+impl From<&SocketAddr> for PeerAddr {
+    fn from(peer: &SocketAddr) -> Self {
+        let ip = match peer.ip() {
+            IpAddr::V4(v4) => v4.to_ipv6_mapped().into(),
+            IpAddr::V6(v6) => v6.into(),
+        };
+
+        Self {
+            ip,
+            port: peer.port()
+        }
+    }
+}
+
+impl From<&PeerAddr> for SocketAddr {
+    fn from(peer: &PeerAddr) -> Self {
+        let ip = Ipv6Addr::from(peer.ip);
+        let ip = ip
+            .to_ipv4()
+            .map(IpAddr::V4)
+            .unwrap_or_else(|| IpAddr::V6(ip));
+
+        SocketAddr::new(ip, peer.port)
+    }
+}
+
+impl From<SocketAddr> for PeerAddr {
+    fn from(peer: SocketAddr) -> Self {
+        Self::from(&peer)
+    }
+}
+
+impl From<PeerAddr> for SocketAddr {
+    fn from(peer: PeerAddr) -> Self {
+        Self::from(&peer)
+    }
+}
+
+impl fmt::Display for PeerAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        SocketAddr::from(self).fmt(f)
+    }
+}


### PR DESCRIPTION
This PR is primarily about reducing memory use - originally measured at about a kilobyte per connection, and now around 300 bytes.

Instead of spawning a task per connection, we now just keep a bunch of vecs of connections and cycle through them on a single shared timer, making one-off write attempts on each one as we go.  Effort has been made to minimise the size of a connection, with custom types for storing the remote address and connection time.

In practice this only amounts to a couple of megabytes of savings even for 8,000 connections, but it was fun to do and I kind of prefer the structure now.

As a side-effect, tarssh is now strictly single-threaded, and the `--threads` option has been removed.

This also clears up signal handling, while adding SIGINFO support.  We also now track bytes written per connection and globally, and total clients served.

Now when we hit the connection limit, we stop accepting new connections instead of instantly closing them.

Finally, the poem is now longer, and sent line by line.