### PR TITLE
Fix inconsistency in logging of peer address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -310,7 +310,6 @@ async fn main() {
                         num_clients += 1;
                         total_clients += 1;
 
-                        info!("connect, peer: {}, clients: {}", peer, num_clients);
                         let connection = Connection {
                             sock,
                             peer: peer.into(),
@@ -318,6 +317,7 @@ async fn main() {
                             bytes: 0,
                             failed: 0,
                         };
+                        info!("connect, peer: {}, clients: {}", connection.peer, num_clients);
                         slots[last_tick].push(connection);
                     }
                     Err(err) => match err.kind() {


### PR DESCRIPTION
Log the PeerAddr for both connect and disconnect, to avoid this inconsistency:

```
[INFO  tarssh] connect, peer: [::ffff:218.92.0.97]:34634, clients: 4
[INFO  tarssh] disconnect, peer: 218.92.0.97:34634, duration: 20.00s, bytes: 24, error: "Broken pipe (os error 32)", clients: 3
```